### PR TITLE
Colors for different states should now be accurately set and displayed.

### DIFF
--- a/JSQFlatButton/Classes/JSQFlatButton.h
+++ b/JSQFlatButton/Classes/JSQFlatButton.h
@@ -23,17 +23,17 @@
  *  @warning If the current value of disabledBackgroundColor is `nil`, then setting this property also sets disabledBackgroundColor to the same color value with a darkened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalBackgroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *normalBackgroundColor;
 
 /**
  *  The background color of the button in its highlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedBackgroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *highlightedBackgroundColor;
 
 /**
  *  The background color of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledBackgroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *disabledBackgroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its default state. The default value is `nil`.
@@ -43,17 +43,17 @@
  *  @warning If the current value of disabledForegroundColor is `nil`, then setting this property also sets disabledForegroundColor to the same color value with a lightened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalForegroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *normalForegroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its highlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedForegroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *highlightedForegroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledForegroundColor;
+@property (strong, nonatomic) IBInspectable UIColor *disabledForegroundColor;
 
 /**
  *  The border color of the button in its default state. The default value is `nil`.
@@ -63,27 +63,27 @@
  *  @warning If the current value of disabledBorderColor is `nil`, then setting this property also sets disabledBorderColor to the same color value with a lightened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalBorderColor;
+@property (strong, nonatomic) IBInspectable UIColor *normalBorderColor;
 
 /**
  *  The border color of the button in its hightlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedBorderColor;
+@property (strong, nonatomic) IBInspectable UIColor *highlightedBorderColor;
 
 /**
  *  The border color of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledBorderColor;
+@property (strong, nonatomic) IBInspectable UIColor *disabledBorderColor;
 
 /**
  *  The corner radius of the button. The default value is `0.0f`.
  */
-@property (assign, nonatomic) IB_DESIGNABLE CGFloat cornerRadius;
+@property (assign, nonatomic) IBInspectable CGFloat cornerRadius;
 
 /**
  *  The border width of the button. The default value is `0.0f`.
  */
-@property (assign, nonatomic) IB_DESIGNABLE CGFloat borderWidth;
+@property (assign, nonatomic) IBInspectable CGFloat borderWidth;
 
 #pragma mark - Initialization
 

--- a/JSQFlatButton/Classes/JSQFlatButton.h
+++ b/JSQFlatButton/Classes/JSQFlatButton.h
@@ -23,17 +23,17 @@
  *  @warning If the current value of disabledBackgroundColor is `nil`, then setting this property also sets disabledBackgroundColor to the same color value with a darkened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) UIColor *normalBackgroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalBackgroundColor;
 
 /**
  *  The background color of the button in its highlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *highlightedBackgroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedBackgroundColor;
 
 /**
  *  The background color of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *disabledBackgroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledBackgroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its default state. The default value is `nil`.
@@ -43,17 +43,17 @@
  *  @warning If the current value of disabledForegroundColor is `nil`, then setting this property also sets disabledForegroundColor to the same color value with a lightened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) UIColor *normalForegroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalForegroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its highlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *highlightedForegroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedForegroundColor;
 
 /**
  *  The foreground color (the text color and image mask color) of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *disabledForegroundColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledForegroundColor;
 
 /**
  *  The border color of the button in its default state. The default value is `nil`.
@@ -63,27 +63,27 @@
  *  @warning If the current value of disabledBorderColor is `nil`, then setting this property also sets disabledBorderColor to the same color value with a lightened brightness value and alpha value of `0.75f`.
  *
  */
-@property (strong, nonatomic) UIColor *normalBorderColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *normalBorderColor;
 
 /**
  *  The border color of the button in its hightlighted state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *highlightedBorderColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *highlightedBorderColor;
 
 /**
  *  The border color of the button in its disabled state. The default value is `nil`.
  */
-@property (strong, nonatomic) UIColor *disabledBorderColor;
+@property (strong, nonatomic) IB_DESIGNABLE UIColor *disabledBorderColor;
 
 /**
  *  The corner radius of the button. The default value is `0.0f`.
  */
-@property (assign, nonatomic) CGFloat cornerRadius;
+@property (assign, nonatomic) IB_DESIGNABLE CGFloat cornerRadius;
 
 /**
  *  The border width of the button. The default value is `0.0f`.
  */
-@property (assign, nonatomic) CGFloat borderWidth;
+@property (assign, nonatomic) IB_DESIGNABLE CGFloat borderWidth;
 
 #pragma mark - Initialization
 

--- a/JSQFlatButton/Classes/JSQFlatButton.m
+++ b/JSQFlatButton/Classes/JSQFlatButton.m
@@ -129,6 +129,60 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
     }
 }
 
+- (void)setHighlightedBackgroundColor:(UIColor *)highlightedBackgroundColor
+{
+    _highlightedBackgroundColor = highlightedBackgroundColor;
+
+    if (self.highlighted) {
+        [self refreshHighlightedState];
+    }
+}
+
+- (void)setHighlightedForegroundColor:(UIColor *)highlightedForegroundColor
+{
+    _highlightedForegroundColor = highlightedForegroundColor;
+
+    if (self.highlighted) {
+        [self refreshHighlightedState];
+    }
+}
+
+- (void)setHighlightedBorderColor:(UIColor *)highlightedBorderColor
+{
+    _highlightedBorderColor = highlightedBorderColor;
+
+    if (self.highlighted) {
+        [self refreshHighlightedState];
+    }
+}
+
+- (void)setDisabledBackgroundColor:(UIColor *)disabledBackgroundColor
+{
+    _disabledBackgroundColor = disabledBackgroundColor;
+
+    if (!self.enabled) {
+        [self refreshEnabledState];
+    }
+}
+
+- (void)setDisabledForegroundColor:(UIColor *)disabledForegroundColor
+{
+    _disabledForegroundColor = disabledForegroundColor;
+
+    if (!self.enabled) {
+        [self refreshEnabledState];
+    }
+}
+
+- (void)setDisabledBorderColor:(UIColor *)disabledBorderColor
+{
+    _disabledBorderColor = disabledBorderColor;
+
+    if (!self.enabled) {
+        [self refreshEnabledState];
+    }
+}
+
 - (void)setCornerRadius:(CGFloat)cornerRadius
 {
     self.layer.cornerRadius = cornerRadius;
@@ -172,24 +226,34 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
           forState:UIControlStateDisabled];
 }
 
+- (void)refreshHighlightedState
+{
+    self.backgroundColor = self.highlighted ? self.highlightedBackgroundColor : self.normalBackgroundColor;
+    self.tintColor = self.highlighted ? self.highlightedForegroundColor : self.normalForegroundColor;
+    self.layer.borderColor = self.highlighted ? self.highlightedBorderColor.CGColor : self.normalBorderColor.CGColor;
+    [self setNeedsDisplay];
+}
+
+- (void)refreshEnabledState
+{
+    self.backgroundColor = self.enabled ? self.normalBackgroundColor : self.disabledBackgroundColor;
+    self.tintColor = self.enabled ? self.normalForegroundColor : self.disabledForegroundColor;
+    self.layer.borderColor = self.enabled ? self.normalBorderColor.CGColor : self.disabledBorderColor.CGColor;
+    [self setNeedsDisplay];
+}
+
 #pragma mark - UIButton
 
 - (void)setHighlighted:(BOOL)highlighted
 {
     [super setHighlighted:highlighted];
-    self.backgroundColor = highlighted ? self.highlightedBackgroundColor : self.normalBackgroundColor;
-    self.tintColor = highlighted ? self.highlightedForegroundColor : self.normalForegroundColor;
-    self.layer.borderColor = highlighted ? self.highlightedBorderColor.CGColor : self.normalBorderColor.CGColor;
-    [self setNeedsDisplay];
+    [self refreshHighlightedState];
 }
 
 - (void)setEnabled:(BOOL)enabled
 {
     [super setEnabled:enabled];
-    self.backgroundColor = enabled ? self.normalBackgroundColor : self.disabledBackgroundColor;
-    self.tintColor = enabled ? self.normalForegroundColor : self.disabledForegroundColor;
-    self.layer.borderColor = enabled ? self.normalBorderColor.CGColor : self.disabledBorderColor.CGColor;
-    [self setNeedsDisplay];
+    [self refreshEnabledState];
 }
 
 #pragma mark - Utilities

--- a/JSQFlatButton/Classes/JSQFlatButton.m
+++ b/JSQFlatButton/Classes/JSQFlatButton.m
@@ -13,21 +13,6 @@
 
 static CGFloat const kJSQColorAlphaDisabled = 0.75f;
 
-@interface JSQFlatButton ()
-
-- (void)jsq_setup;
-
-- (void)jsq_refreshTitleAndImage;
-
-- (UIColor *)jsq_darkenedColorFromColor:(UIColor *)color;
-- (UIColor *)jsq_lightenedColorFromColor:(UIColor *)color;
-
-- (UIImage *)jsq_image:(UIImage *)image maskedWithColor:(UIColor *)maskColor;
-
-@end
-
-
-
 @implementation JSQFlatButton
 
 #pragma mark - Initialization
@@ -64,21 +49,6 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
         [self jsq_setup];
     }
     return self;
-}
-
-- (void)dealloc
-{
-    _normalBackgroundColor = nil;
-    _highlightedBackgroundColor = nil;
-    _disabledBackgroundColor = nil;
-    
-    _normalForegroundColor = nil;
-    _highlightedForegroundColor = nil;
-    _disabledForegroundColor = nil;
-    
-    _normalBorderColor = nil;
-    _highlightedBorderColor = nil;
-    _disabledBorderColor = nil;
 }
 
 #pragma mark - Setters
@@ -205,9 +175,9 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
     
     [self setTitle:title forState:UIControlStateNormal];
     
-    [self setTitleColor:_normalForegroundColor forState:UIControlStateNormal];
-    [self setTitleColor:_highlightedForegroundColor forState:UIControlStateHighlighted];
-    [self setTitleColor:_disabledForegroundColor forState:UIControlStateDisabled];
+    [self setTitleColor:self.normalForegroundColor forState:UIControlStateNormal];
+    [self setTitleColor:self.highlightedForegroundColor forState:UIControlStateHighlighted];
+    [self setTitleColor:self.disabledForegroundColor forState:UIControlStateDisabled];
 }
 
 - (void)setFlatImage:(UIImage *)image
@@ -217,13 +187,13 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
         return;
     }
     
-    [self setImage:[self jsq_image:image maskedWithColor:_normalForegroundColor]
+    [self setImage:[self jsq_image:image maskedWithColor:self.normalForegroundColor]
           forState:UIControlStateNormal];
     
-    [self setImage:[self jsq_image:image maskedWithColor:_highlightedForegroundColor]
+    [self setImage:[self jsq_image:image maskedWithColor:self.highlightedForegroundColor]
           forState:UIControlStateHighlighted];
     
-    [self setImage:[self jsq_image:image maskedWithColor:_disabledForegroundColor]
+    [self setImage:[self jsq_image:image maskedWithColor:self.disabledForegroundColor]
           forState:UIControlStateDisabled];
 }
 

--- a/JSQFlatButton/Classes/JSQFlatButton.m
+++ b/JSQFlatButton/Classes/JSQFlatButton.m
@@ -117,7 +117,6 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
 
 - (void)setNormalBorderColor:(UIColor *)normalBorderColor
 {
-    self.layer.borderColor = normalBorderColor.CGColor;
     _normalBorderColor = normalBorderColor;
     
     if (!_highlightedBorderColor) {
@@ -127,6 +126,8 @@ static CGFloat const kJSQColorAlphaDisabled = 0.75f;
     if (!_disabledBorderColor) {
         _disabledBorderColor = [_highlightedBorderColor colorWithAlphaComponent:kJSQColorAlphaDisabled];
     }
+    [self refreshHighlightedState];
+    [self refreshEnabledState];
 }
 
 - (void)setHighlightedBackgroundColor:(UIColor *)highlightedBackgroundColor


### PR DESCRIPTION
Setting various colors regardless of the order they are set in should now update the appearance of the button properly, especially if the button is already highlighted or disabled when the colors are set.
